### PR TITLE
Added basic support of multi-bit ports for gate-level netlists

### DIFF
--- a/circuitgraph/parsing/verilog.lark
+++ b/circuitgraph/parsing/verilog.lark
@@ -21,9 +21,9 @@ list_of_ports: "(" port ("," port)* ")"
 
 
 // 2. Declarations
-input_declaration: "input" list_of_variables ";"
+input_declaration: "input" [range] list_of_variables ";"
 
-output_declaration: "output" list_of_variables ";"
+output_declaration: "output" [range] list_of_variables ";"
 
 net_declaration: "wire" list_of_variables ";"
 
@@ -33,6 +33,7 @@ list_of_variables: IDENTIFIER ("," IDENTIFIER)*
 
 list_of_assignments: assignment ("," assignment)*
 
+range: "[" INT ":" INT "]"
 
 // 3. Primitive Instances
 // These are merged with module instantiations
@@ -116,6 +117,7 @@ not_gate: ( "!" | "~" ) primary
 
 IDENTIFIER: CNAME
           | ESCAPED_IDENTIFIER
+          | CNAME "[" INT "]"
 
 
 // Lark
@@ -127,6 +129,7 @@ MULTILINE_COMMENT: /\/\*(\*(?!\/)|[^*])*\*\//
 %import common.CNAME
 %import common.ESCAPED_STRING
 %import common.WS
+%import common.INT
 
 %ignore WS
 %ignore COMMENT

--- a/circuitgraph/parsing/verilog.py
+++ b/circuitgraph/parsing/verilog.py
@@ -203,13 +203,27 @@ class _VerilogCircuitGraphTransformer(Transformer):
 
     # 2. Declarations
     def input_declaration(self, list_of_variables):
-        [list_of_variables] = list_of_variables
+        r = list_of_variables[0]
+        l=list_of_variables[1]
+        if r:
+            self.io.remove(l[0])
+            list_of_variables = [f'''{l[0]}[{i}]''' for i in range(int(r.children[1]), int(r.children[0]) + 1)]
+            self.io.update(list_of_variables)
+        else:
+            list_of_variables= l
         self.inputs.update(list_of_variables)
         for variable in list_of_variables:
             self.add_node(variable, "input")
 
     def output_declaration(self, list_of_variables):
-        [list_of_variables] = list_of_variables
+        r = list_of_variables[0]
+        l = list_of_variables[1]
+        if r:
+            self.io.remove(l[0])
+            list_of_variables = [f'''{l[0]}[{i}]''' for i in range(int(r.children[1]), int(r.children[0]) + 1)]
+            self.io.update(list_of_variables)
+        else:
+            list_of_variables = l
         self.outputs.update(list_of_variables)
 
     def net_declaration(self, list_of_variables):


### PR DESCRIPTION
Added support of multi-bit ports e.g. "input [3:0] portA". The patch is limited to gate-level netlists.